### PR TITLE
removed unused devscreen references from navigation

### DIFF
--- a/App/Navigation/AppNavigation.js
+++ b/App/Navigation/AppNavigation.js
@@ -1,18 +1,11 @@
 import { StackNavigator } from 'react-navigation'
 import TextablesScreen from '../Containers/TextablesScreen'
-import LaunchScreen from '../Containers/LaunchScreen'
-import LoginScreen from '../Containers/LoginScreen'
 
 import styles from './Styles/NavigationStyles'
 
 // Manifest of possible screens
 const PrimaryNav = StackNavigator({
-  TextablesScreen: { screen: TextablesScreen },
-  LaunchScreen: { screen: LaunchScreen },
-  LoginScreen: {
-    screen: LoginScreen,
-    navigationOptions: { title: 'Login' }
-  }
+  TextablesScreen: { screen: TextablesScreen }
 }, {
   // Default config for all screens
   headerMode: 'none',


### PR DESCRIPTION
Leaving these unused references causes the UWP app to crash (because we're not using a UWP compatible version of the ReactNativeDeviceInfo package).